### PR TITLE
Updated ranking button behavior and sytles

### DIFF
--- a/NYBRI/css/style.css
+++ b/NYBRI/css/style.css
@@ -525,3 +525,28 @@ nav a {
         left: 92%;
     }
 }
+
+/* updated for ranking button : 2/20/2024 */
+/* Styles for the disabled state */
+button:disabled {
+    background-color: grey;
+    color: white;
+    cursor: not-allowed;
+  }
+  
+  /* Styles for the enabled state */
+  button:not(:disabled) {
+    background-color: blue;
+    color: white;
+    cursor: pointer;
+  }
+
+  /* Hover effect for the enabled button */
+button:not(:disabled):hover {
+    background-color: #bfbfbf; /* light grey */
+  }
+  
+  /* Hover effect for the disabled button */
+  button:disabled:hover {
+    background-color: #bfbfbf; /* light grey */
+  }

--- a/NYBRI/js/index.js
+++ b/NYBRI/js/index.js
@@ -214,6 +214,7 @@ myApp.controller('myController', function ($scope) {
 			cashAdvance: 0
 		
 	}}];
+
 	
 	// ==============================================================
 	// END OF NEW VARIABLES
@@ -766,3 +767,10 @@ myApp.controller('myController', function ($scope) {
     };
 
 });
+
+// updated for ranking button : 2/20/2024
+$scope.finalScore = function () {
+    if ($scope.calculateTotal() === 100) {
+        $scope.showme = true; 
+    }
+};

--- a/NYBRI/ratings.html
+++ b/NYBRI/ratings.html
@@ -135,11 +135,17 @@
                         <div>
                             <div id="slider-container" class="slider-container">
                                 <p>In this section, you can enter weights for any of the 20 categories used for ranking banks. If the value typed into the box isn't valid, it will automatically be set to 0. When your Total Percent is 100, you can click "Calculate Bank Scores" to produce a customized table with banks listed from best to worst.</p>
+                                <!-- Updated ver for Button with disable/inable function respect to Total Percent -->
                                 <div class="visible-label">
                                     <label><strong>Total Percent:</strong> {{ calculateTotal() }}
-                                        <br><strong>Remaining:</strong> {{ 100 - calculateTotal()}}</label>
-                                    <button type="button" ng-click="finalScore(); showme='true'">Calculate Bank Scores</button>
+                                        <br><strong>Remaining:</strong> {{ 100 - calculateTotal() }}</label>
+                                    <button type="button" 
+                                            ng-click="finalScore(); showme=true" 
+                                            ng-disabled="calculateTotal() !== 100">
+                                            Calculate Bank Scores
+                                    </button>
                                 </div>
+                                <!-- Updated End Here : 2/20/2024 -->
                             </div>
                             <div class="form-container">
                                 <form>
@@ -301,11 +307,17 @@
                         <div>
                             <div id="slider-container" class="slider-container">
                                 <p>In this section, you can enter weights for any of the 20 categories used for ranking FINTECH. If the value typed into the box isn't valid, it will automatically be set to 0. When your Total Percent is 100, you can click "Calculate FINTECH Scores" to produce a customized table with banks listed from best to worst.</p>
+                                <!-- Updated ver for Button with disable/inable function respect to Total Percent -->
                                 <div class="visible-label">
                                     <label><strong>Total Percent:</strong> {{ calculateTotal() }}
-                                        <br><strong>Remaining:</strong> {{ 100 - calculateTotal()}}</label>
-                                    <button type="button" ng-click="finalScore(); showme='true'">Calculate FINTECH scores</button>
+                                        <br><strong>Remaining:</strong> {{ 100 - calculateTotal() }}</label>
+                                    <button type="button" 
+                                            ng-click="finalScore(); showme=true" 
+                                            ng-disabled="calculateTotal() !== 100">
+                                            Calculate FINTECH Scores
+                                    </button>
                                 </div>
+                                <!-- Updated End Here : 2/20/2024 -->
                             </div>
                             <div class="form-container">
                                 <form>


### PR DESCRIPTION
I've made some updates to our NYBRI website, specifically addressing the behavior of the 'Calculate Fintech Scores' and 'Calculate Bank Scores' buttons, initially highlighted by James in his comment (<!-- err: Have no idea why this isn't changing the buttons-->). 

Through the review process, my guess was that the intention behind the comment was to implement functionality where the button becomes visible only when the "Total Percent" equals 100, and remains hidden otherwise.

**What's changed:** 

Instead of making the button appear or disappear, I have made it always visible but becomes clickable (enabled) only when the total percentage of weights entered by the user equals 100. When it's not 100, the button is disabled (greyed out and unclickable).

Added specific CSS rules to change the button's appearance based on its state (enabled/disabled) and hover effect. When the total percent is not equal to 100, the button now appears grey and shows a 'not-allowed' cursor to indicate it's unclickable. Upon reaching a total percent of 100, the button turns blue and the cursor changes to 'pointer', signaling it's clickable. 

I've kept the original <div class="hidden-label"> codes intact as a fallback. If these changes do not align with the original intentions, I'm open to reverting them. Please review and let me know your thoughts.

If anyone agrees with these updates, or if these changes align with our previous objectives, please let me know by approving the pull request. Alternatively, just let me know if you agree, and then I'll go ahead and remove the <div class="hidden-label"> section and submit a new pull request for a cleaner merge.
